### PR TITLE
solve problems caused by version 0.0.13

### DIFF
--- a/docs/zh-Hant/release-note.md
+++ b/docs/zh-Hant/release-note.md
@@ -1,3 +1,16 @@
+v0.0.14
+======
+
+本次更新主要修复了 v0.0.13 带出的问题。
+
+1. 移除 run_in_loop 函数以及 loop.call_soon，使用 `loop.run_until_complete` 替代
+2. 增加 ipython 未安装的警告
+3. 更改模版中的 unfazed 版本号
+4. 修复的 admin 组件中 `Model_saveBodyModel` 的 bug
+5. 调整部份测试代码
+
+
+
 v0.0.13
 ======
 - [issue 57](https://github.com/unfazed-eco/unfazed/issues/57) 使用 ipython 实现 shell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unfazed"
-version = "0.0.13"
+version = "0.0.14"
 description = "Production ready async python web framework"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -52,6 +52,7 @@ asyncio_default_fixture_loop_scope = "session"
 testpaths = [
     "tests",
 ]
+
 
 
 [tool.coverage.report]

--- a/tests/test_cli/test_main.py
+++ b/tests/test_cli/test_main.py
@@ -16,7 +16,7 @@ def setup_cli_env() -> t.Generator[None, None, None]:
     yield
 
 
-async def test_main() -> None:
+def test_main() -> None:
     with patch("unfazed.command.CliCommandCenter.main") as main_func:
         main_func.return_value = None
         main()

--- a/tests/test_command/test_command_registry.py
+++ b/tests/test_command/test_command_registry.py
@@ -14,14 +14,14 @@ SETTINGS = {
 }
 
 
-async def test_command_center() -> None:
+def test_command_center() -> None:
     _SETTINGS = {
         **SETTINGS,
         "INSTALLED_APPS": ["tests.apps.cmd.common"],
     }
     unfazed = Unfazed(settings=UnfazedSettings.model_validate(_SETTINGS))
-
-    await unfazed.setup()
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(unfazed.setup())
 
     command_center = unfazed.command_center
     assert "common" in command_center.commands
@@ -29,11 +29,11 @@ async def test_command_center() -> None:
     assert "sync-common" in command_center.commands
 
     cmd = t.cast(BaseCommand, command_center.commands["common"])
-    loop = asyncio.get_event_loop()
-    loop.call_soon(cmd.handle())
+
+    loop.call_soon(cmd._callback())
 
     cmd = t.cast(BaseCommand, command_center.commands["sync-common"])
-    loop.call_soon(cmd.handle())
+    loop.call_soon(cmd._callback())
 
 
 async def test_cmd_failed() -> None:

--- a/tests/test_contrib/test_admin/entry/settings.py
+++ b/tests/test_contrib/test_admin/entry/settings.py
@@ -23,4 +23,8 @@ UNFAZED_SETTINGS = {
             }
         }
     },
+    "OPENAPI": {
+        "servers": [{"url": "http://127.0.0.1:9527", "description": "Local"}],
+        "info": {"title": "myproject", "version": "1.0.0", "description": "desc"},
+    },
 }

--- a/tests/test_contrib/test_admin/test_admin_endpoints.py
+++ b/tests/test_contrib/test_admin/test_admin_endpoints.py
@@ -162,6 +162,10 @@ async def test_endpoints(setup_admin_unfazed: Unfazed) -> None:
 
         assert resp11.status_code == 200
 
+        # test openapi integration
+        resp12 = await request.get("/openapi/openapi.json")
+        assert resp12.status_code == 200
+
 
 async def test_endpoints_with_unknown_user(setup_admin_unfazed: Unfazed) -> None:
     with patch.object(HttpRequest, "user", UnkownUser()):

--- a/tests/test_openapi/test_openapi_cmd.py
+++ b/tests/test_openapi/test_openapi_cmd.py
@@ -13,6 +13,6 @@ async def test_export_openapi_cmd(
     unfazed = setup_openapi_unfazed
 
     cmd = Command(unfazed, "export_openapi", "internal")
-    await cmd.handle(location=tmp_dir)
+    cmd.handle(location=tmp_dir)
 
     assert Path(tmp_dir / "openapi.yaml").exists()

--- a/unfazed/cli.py
+++ b/unfazed/cli.py
@@ -29,15 +29,6 @@ def import_unfazed(current_path: str) -> t.Optional[Unfazed]:
     return module.application
 
 
-def run_in_loop(loop: asyncio.AbstractEventLoop, coro: t.Coroutine) -> None:
-    if loop.is_running():
-        # this line will take effect when run test
-        asyncio.ensure_future(coro, loop=loop)
-    else:
-        # this line will take effect using unfazed-cli shell
-        loop.run_until_complete(coro)  # pragma: no cover
-
-
 def _main() -> None:
     current_path = os.getcwd()
     maybeapp = import_unfazed(current_path)
@@ -46,11 +37,11 @@ def _main() -> None:
 
     if maybeapp is None:
         app = Unfazed()
-        run_in_loop(loop, app.setup_cli())
+        loop.run_until_complete(app.setup_cli())
         app.execute_command_from_cli()
     else:
         app = maybeapp
-        run_in_loop(loop, app.setup())
+        loop.run_until_complete(app.setup())
         app.execute_command_from_argv()
 
 

--- a/unfazed/command/base.py
+++ b/unfazed/command/base.py
@@ -143,7 +143,8 @@ class BaseCommand(ClickCommand, ABC):
 
         if asyncio.iscoroutinefunction(self.handle):
             # Handle async method
-            asyncio.run(self.handle(**options))
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(self.handle(**options))
         else:
             # Handle sync method
             self.handle(**options)

--- a/unfazed/command/internal/export_openapi.py
+++ b/unfazed/command/internal/export_openapi.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
         ]
 
     @t.override
-    async def handle(self, **options: t.Any) -> None:
+    def handle(self, **options: t.Any) -> None:
         assert yaml is not None, "yaml is not installed"
         assert OpenApi.schema is not None, "OpenAPI schema is not found"
 

--- a/unfazed/command/internal/shell.py
+++ b/unfazed/command/internal/shell.py
@@ -3,9 +3,10 @@ import warnings
 
 try:
     from IPython import start_ipython
+
     IPYTHON_AVAILABLE = True
-except ImportError:
-    IPYTHON_AVAILABLE = False
+except ImportError:  # pragma: no cover
+    IPYTHON_AVAILABLE = False  # pragma: no cover
 
 from unfazed.command import BaseCommand
 
@@ -40,7 +41,5 @@ class Command(BaseCommand):
             start_ipython(argv=[], user_ns=user_ns, exec_lines=startup_code)  # type: ignore
         else:
             warnings.warn(
-                "IPython is not installed.",
-                UserWarning,
-                stacklevel=2
-            )
+                "IPython is not installed.", UserWarning, stacklevel=2
+            )  # pragma: no cover

--- a/unfazed/command/registry.py
+++ b/unfazed/command/registry.py
@@ -104,7 +104,6 @@ class CommandCenter(Base):
 
         # Load all the commands from the unfazed internal
         internal_commands = self.list_internal_command()
-        print(f"internal commands = {internal_commands}")
         for command in internal_commands:
             self.load_command(command)
 

--- a/unfazed/contrib/admin/schema/request.py
+++ b/unfazed/contrib/admin/schema/request.py
@@ -45,10 +45,15 @@ class Save(BaseModel):
         t.Dict[str, t.List[t.Dict[str, t.Any]]],
         Doc(
             description="relation model to `data`, use unfazed.contrib.auth.models.Group as example",
-            examples={
-                "groups": [{"name": "group1", "id": 1}, {"name": "group2", "id": 2}],
-                "roles": [{"name": "role1", "id": 1}, {"name": "role2", "id": 2}],
-            },
+            examples=[
+                {
+                    "groups": [
+                        {"name": "group1", "id": 1},
+                        {"name": "group2", "id": 2},
+                    ],
+                    "roles": [{"name": "role1", "id": 1}, {"name": "role2", "id": 2}],
+                }
+            ],
         ),
     ]
 

--- a/unfazed/template/project/{{ project_name }}/src/backend/pyproject.toml
+++ b/unfazed/template/project/{{ project_name }}/src/backend/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 description = "A {{ project_name }} project."
 authors = []
 dependencies = [
-    "unfazed>=0.0.4",
+    "unfazed>=0.0.14",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
1. 移除 run_in_loop 函数以及 loop.call_soon，使用  run_until_complete 替代
2. 增加 ipython 未安装的警告
3. 更改模版中的 unfazed 版本号
4. 修复的 admin 组件中  的 bug
5. 调整部份测试代码