### PR TITLE
fix: static & route

### DIFF
--- a/unfazed/http/response.py
+++ b/unfazed/http/response.py
@@ -470,6 +470,7 @@ class FileResponse(StreamingResponse):
         chunk_size: int = 65536,
         headers: t.Dict[str, str] | None = None,
         background: BackgroundTask | None = None,
+        media_type: str = "application/octet-stream",
     ) -> None:
         handler = RangeFileHandler(path, filename, chunk_size)
 
@@ -484,7 +485,7 @@ class FileResponse(StreamingResponse):
             status_code,
             resp_headers,
             background=background,
-            media_type="application/octet-stream",
+            media_type=media_type,
         )
 
     def build_headers(self, handler: RangeFileHandler) -> t.Dict[str, str]:

--- a/unfazed/route/endpoint.py
+++ b/unfazed/route/endpoint.py
@@ -447,6 +447,9 @@ class EndPointDefinition(BaseModel):
 
             annotation, fieldinfo = define
 
+            # Save original annotation for issubclass check before potential modification
+            original_annotation: t.Type = annotation
+
             # Uploadfile need special json schema
             if issubclass(annotation, UploadFile):
                 new_json_schema_extra = {"type": "string", "format": "binary"}
@@ -458,7 +461,7 @@ class EndPointDefinition(BaseModel):
             if hasattr(fieldinfo, "media_type"):
                 json_schema_extra["media_type"] = fieldinfo.media_type
 
-            if issubclass(annotation, BaseModel):
+            if issubclass(original_annotation, BaseModel):
                 for field_name, field in annotation.model_fields.items():
                     if field_name in fields:
                         raise ValueError(f"field {field_name} already exists")

--- a/unfazed/static/base.py
+++ b/unfazed/static/base.py
@@ -1,3 +1,4 @@
+import mimetypes
 from pathlib import Path
 from typing import Union
 
@@ -44,7 +45,10 @@ class StaticFiles:
     ) -> Union[FileResponse, HtmlResponse]:
         if html:
             return HtmlResponse(path.read_text(encoding="utf-8"))
-        return FileResponse(path)
+        media_type = mimetypes.guess_type(path.name)[0]
+        if media_type is None:
+            media_type = "text/plain"
+        return FileResponse(path, media_type=media_type)
 
     def lookup_path(self, scope: Scope) -> Path:
         # Combine path operations


### PR DESCRIPTION
### **User description**
#84 
#82


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add configurable `media_type` parameter to `FileResponse` for flexible content type handling

- Fix static file serving to properly detect and set MIME types based on file extensions

- Fix `issubclass` check in route endpoint to use original annotation before potential modification

- Improve file response handling with fallback to `text/plain` for unknown file types


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FileResponse init"] -->|Add media_type param| B["Configurable content type"]
  C["Static file serving"] -->|Detect MIME type| D["Proper file response"]
  E["Route endpoint params"] -->|Use original annotation| F["Correct type checking"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>response.py</strong><dd><code>Make FileResponse media type configurable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unfazed/http/response.py

<ul><li>Add <code>media_type</code> parameter to <code>FileResponse.__init__()</code> with default value <br><code>"application/octet-stream"</code><br> <li> Pass the <code>media_type</code> parameter to parent class instead of hardcoding it<br> <li> Allows callers to override the default media type when creating file <br>responses</ul>


</details>


  </td>
  <td><a href="https://github.com/unfazed-eco/unfazed/pull/85/files#diff-fc5a9b1e679edc661b7e9cfd80c1d2b5730f2fbac4c3e5dd0829469b1d0fc699">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>endpoint.py</strong><dd><code>Fix issubclass check with original annotation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unfazed/route/endpoint.py

<ul><li>Save original annotation before potential modification in <br><code>create_param_model()</code><br> <li> Use <code>original_annotation</code> for <code>issubclass()</code> check instead of potentially <br>modified <code>annotation</code><br> <li> Prevents <code>TypeError</code> when checking if modified annotation is subclass of <br><code>BaseModel</code></ul>


</details>


  </td>
  <td><a href="https://github.com/unfazed-eco/unfazed/pull/85/files#diff-86491502dac48374d6a0554705bcf72430d24d491912fb5ada127ce443eea30f">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>base.py</strong><dd><code>Detect and set MIME types for static files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unfazed/static/base.py

<ul><li>Import <code>mimetypes</code> module for MIME type detection<br> <li> Detect MIME type from file extension using <code>mimetypes.guess_type()</code><br> <li> Pass detected <code>media_type</code> to <code>FileResponse</code> constructor<br> <li> Add fallback to <code>"text/plain"</code> when MIME type cannot be determined</ul>


</details>


  </td>
  <td><a href="https://github.com/unfazed-eco/unfazed/pull/85/files#diff-dbe6d087351237ea087661b99dc6ca88f2fb62f32e3f9f4ce9b3bd79ad7de278">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

