### PR TITLE
fix: avoid redundant EndPointDefinition recreation in Route.update_pa…

### DIFF
--- a/tests/test_route/test_route_base.py
+++ b/tests/test_route/test_route_base.py
@@ -180,6 +180,17 @@ def test_route() -> None:
     assert match == Match.NONE
 
 
+def test_update_path_no_redundant_endpoint_definition() -> None:
+    route = Route("/prefix/{id}", view, methods=["GET"], tags=["tag"])
+    original_definition = route.endpoint_definition
+
+    route.update_path("/new_prefix/{id}")
+    assert route.endpoint_definition is original_definition
+
+    route.update_path("/new_prefix/{id}/{detail_id}")
+    assert route.endpoint_definition is not original_definition
+
+
 class LangConvertor(Convertor):
     regex = r"[-_a-zA-Z]+"
 

--- a/unfazed/route/routing.py
+++ b/unfazed/route/routing.py
@@ -93,17 +93,20 @@ class Route(StartletteRoute):
 
     def update_path(self, new_path: str) -> None:
         self.path = new_path
+
+        original_param_convertor_keys = self.param_convertors.keys()
         self.path_regex, self.path_format, self.param_convertors = compile_path(
             new_path
         )
 
-        self.endpoint_definition = EndPointDefinition(
-            endpoint=self.endpoint,
-            methods=self.methods,
-            tags=self.tags,
-            path_parm_names=self.param_convertors.keys(),
-            response_models=self.response_models,
-        )
+        if original_param_convertor_keys != self.param_convertors.keys():
+            self.endpoint_definition = EndPointDefinition(
+                endpoint=self.endpoint,
+                methods=self.methods,
+                tags=self.tags,
+                path_parm_names=self.param_convertors.keys(),
+                response_models=self.response_models,
+            )
 
         if self.operation_id:
             self.endpoint_definition.operation_id = self.operation_id

--- a/uv.lock
+++ b/uv.lock
@@ -1102,7 +1102,7 @@ wheels = [
 
 [[package]]
 name = "unfazed"
-version = "0.0.18"
+version = "0.0.19"
 source = { editable = "." }
 dependencies = [
     { name = "aerich" },


### PR DESCRIPTION
…th()

Only rebuild endpoint_definition when path parameter convertors actually change, skipping unnecessary work when only the path prefix is updated.

Closes #98

Made-with: Cursor