### PR TITLE
feat(route): support custom HttpRequest subclass injection in endpoints

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,9 @@ services:
   redis:
     image: redis:latest
     platform: linux/amd64
-    ports:
-      - "127.0.0.1:9528:6379"
   mysql:
     image: mysql:5.7
     platform: linux/amd64
-    ports:
-      - "127.0.0.1:9529:3306"
     environment:
       MYSQL_DATABASE: app
       MYSQL_USER: app
@@ -19,8 +15,6 @@ services:
 
   web:
     build: .
-    ports:
-      - "127.0.0.1:9527:9527"
     depends_on:
       - redis
       - mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,13 @@ services:
   redis:
     image: redis:latest
     platform: linux/amd64
+    ports:
+      - "127.0.0.1:9528:6379"
   mysql:
     image: mysql:5.7
     platform: linux/amd64
+    ports:
+      - "127.0.0.1:9529:3306"
     environment:
       MYSQL_DATABASE: app
       MYSQL_USER: app
@@ -15,6 +19,8 @@ services:
 
   web:
     build: .
+    ports:
+      - "127.0.0.1:9527:9527"
     depends_on:
       - redis
       - mysql

--- a/tests/test_route/test_route_endpoint.py
+++ b/tests/test_route/test_route_endpoint.py
@@ -1046,6 +1046,22 @@ def test_multiple_request_parameters_not_supported() -> None:
         Route(path="/", endpoint=endpoint, methods=["GET"])
 
 
+def test_endpoint_without_any_parameter_is_rejected() -> None:
+    async def endpoint() -> JsonResponse:  # type: ignore[unused-ignore]
+        return JsonResponse({})
+
+    with pytest.raises(ValueError, match="must declare `request: HttpRequest`"):
+        Route(path="/", endpoint=endpoint, methods=["GET"])
+
+
+def test_first_parameter_with_wrong_type_is_rejected() -> None:
+    async def endpoint(ctx: t.Annotated[str, p.Query()]) -> JsonResponse:
+        return JsonResponse({"ctx": ctx})
+
+    with pytest.raises(ValueError, match="request parameter must be the first"):
+        Route(path="/", endpoint=endpoint, methods=["GET"])
+
+
 # ====== test file ======
 
 

--- a/tests/test_route/test_route_endpoint.py
+++ b/tests/test_route/test_route_endpoint.py
@@ -987,6 +987,65 @@ async def test_definition() -> None:
         )
 
 
+async def test_custom_request_class_is_injected() -> None:
+    captured_request: HttpRequest | None = None
+
+    class CustomRequest(HttpRequest):
+        @property
+        def trace_id(self) -> str:
+            return self.headers["x-trace-id"]
+
+    async def endpoint(request: CustomRequest) -> JsonResponse:
+        nonlocal captured_request
+        captured_request = request
+        return JsonResponse({"trace_id": request.trace_id})
+
+    route = Route(path="/", endpoint=endpoint, methods=["GET"])
+
+    assert route.endpoint_definition.request_class is CustomRequest
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "scheme": "https",
+        "server": ("www.example.org", 80),
+        "path": "/",
+        "headers": [(b"x-trace-id", b"trace-123")],
+        "query_string": b"",
+    }
+
+    await route(scope=scope, receive=reiceive, send=send)
+
+    assert isinstance(captured_request, CustomRequest)
+    assert captured_request.trace_id == "trace-123"
+
+
+def test_request_parameter_must_be_first() -> None:
+    class CustomRequest(HttpRequest):
+        pass
+
+    async def endpoint(
+        query1: t.Annotated[str, p.Query()], request: CustomRequest
+    ) -> JsonResponse:
+        return JsonResponse({"query1": query1})
+
+    with pytest.raises(ValueError, match="request parameter must be the first"):
+        Route(path="/", endpoint=endpoint, methods=["GET"])
+
+
+def test_multiple_request_parameters_not_supported() -> None:
+    class CustomRequest(HttpRequest):
+        pass
+
+    async def endpoint(request: HttpRequest, request2: CustomRequest) -> JsonResponse:
+        return JsonResponse({})
+
+    with pytest.raises(
+        ValueError, match="multiple request parameters are not supported"
+    ):
+        Route(path="/", endpoint=endpoint, methods=["GET"])
+
+
 # ====== test file ======
 
 

--- a/tests/test_route/test_route_endpoint.py
+++ b/tests/test_route/test_route_endpoint.py
@@ -1040,23 +1040,9 @@ def test_multiple_request_parameters_not_supported() -> None:
     async def endpoint(request: HttpRequest, request2: CustomRequest) -> JsonResponse:
         return JsonResponse({})
 
-    with pytest.raises(ValueError, match="unsupported type hint for `request2`"):
-        Route(path="/", endpoint=endpoint, methods=["GET"])
-
-
-def test_endpoint_without_any_parameter_is_rejected() -> None:
-    async def endpoint() -> JsonResponse:  # type: ignore[unused-ignore]
-        return JsonResponse({})
-
-    with pytest.raises(ValueError, match="must declare `request: HttpRequest`"):
-        Route(path="/", endpoint=endpoint, methods=["GET"])
-
-
-def test_first_parameter_with_wrong_type_is_rejected() -> None:
-    async def endpoint(ctx: t.Annotated[str, p.Query()]) -> JsonResponse:
-        return JsonResponse({"ctx": ctx})
-
-    with pytest.raises(ValueError, match="request parameter must be the first"):
+    with pytest.raises(
+        ValueError, match="multiple request parameters are not supported"
+    ):
         Route(path="/", endpoint=endpoint, methods=["GET"])
 
 

--- a/tests/test_route/test_route_endpoint.py
+++ b/tests/test_route/test_route_endpoint.py
@@ -1040,9 +1040,7 @@ def test_multiple_request_parameters_not_supported() -> None:
     async def endpoint(request: HttpRequest, request2: CustomRequest) -> JsonResponse:
         return JsonResponse({})
 
-    with pytest.raises(
-        ValueError, match="multiple request parameters are not supported"
-    ):
+    with pytest.raises(ValueError, match="unsupported type hint for `request2`"):
         Route(path="/", endpoint=endpoint, methods=["GET"])
 
 

--- a/unfazed/route/endpoint.py
+++ b/unfazed/route/endpoint.py
@@ -1,6 +1,5 @@
 import inspect
 import typing as t
-from collections import OrderedDict
 
 from pydantic import BaseModel, ConfigDict, Field, WithJsonSchema, create_model
 from starlette.concurrency import run_in_threadpool
@@ -223,28 +222,31 @@ class EndPointDefinition(BaseModel):
         endpoint = self.endpoint
         type_hints = t.get_type_hints(endpoint, include_extras=True)
 
-        od_all_params: OrderedDict[str, inspect.Parameter] = OrderedDict(
-            inspect.signature(endpoint).parameters
-        )
-        if not od_all_params:
-            raise ValueError(
-                f"endpoint `{self.endpoint_name}` must declare `request: HttpRequest` as the first parameter"
-            )
+        signature = inspect.signature(endpoint)
 
-        _, request_param = od_all_params.popitem(last=False)
-        if HttpRequest not in getattr(request_param.annotation, "__mro__", []):
-            raise ValueError(
-                f"request parameter must be the first parameter of endpoint `{self.endpoint_name}`, "
-                f"got `{request_param.name}: {request_param.annotation}`"
-            )
-        self.request_class = t.cast(t.Type[HttpRequest], request_param.annotation)
-
+        # handle endpoint params
         ret: t.Dict[str, inspect.Parameter] = {}
-        for args, param in od_all_params.items():
+        has_request_param = False
+        for index, (args, param) in enumerate(signature.parameters.items()):
             if param.kind in [
                 inspect.Parameter.VAR_KEYWORD,
                 inspect.Parameter.VAR_POSITIONAL,
             ]:
+                continue
+
+            # skip unfazed request
+            mro = getattr(param.annotation, "__mro__", [])
+            if HttpRequest in mro:
+                if has_request_param:
+                    raise ValueError(
+                        f"multiple request parameters are not supported in endpoint: {self.endpoint_name}"
+                    )
+                if index != 0:
+                    raise ValueError(
+                        f"request parameter must be the first parameter in endpoint: {self.endpoint_name}"
+                    )
+                self.request_class = param.annotation
+                has_request_param = True
                 continue
 
             # raise if no type hint

--- a/unfazed/route/endpoint.py
+++ b/unfazed/route/endpoint.py
@@ -45,7 +45,7 @@ class EndpointHandler:
         self.endpoint_definition = endpoint_definition
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        request = HttpRequest(scope, receive, send)
+        request = self.endpoint_definition.request_class(scope, receive, send)
 
         kwargs, error_list = await self.solve_params(request)
 
@@ -183,6 +183,7 @@ class EndPointDefinition(BaseModel):
     methods: t.Set[str]
     tags: t.List[str]
     path_parm_names: t.List[str]
+    request_class: t.Type[HttpRequest] = HttpRequest
 
     # stage 1: convert signature to params and response
     params: t.Dict[str, inspect.Parameter] | None = None
@@ -225,7 +226,8 @@ class EndPointDefinition(BaseModel):
 
         # handle endpoint params
         ret: t.Dict[str, inspect.Parameter] = {}
-        for args, param in signature.parameters.items():
+        has_request_param = False
+        for index, (args, param) in enumerate(signature.parameters.items()):
             if param.kind in [
                 inspect.Parameter.VAR_KEYWORD,
                 inspect.Parameter.VAR_POSITIONAL,
@@ -235,6 +237,16 @@ class EndPointDefinition(BaseModel):
             # skip unfazed request
             mro = getattr(param.annotation, "__mro__", [])
             if HttpRequest in mro:
+                if has_request_param:
+                    raise ValueError(
+                        f"multiple request parameters are not supported in endpoint: {self.endpoint_name}"
+                    )
+                if index != 0:
+                    raise ValueError(
+                        f"request parameter must be the first parameter in endpoint: {self.endpoint_name}"
+                    )
+                self.request_class = param.annotation
+                has_request_param = True
                 continue
 
             # raise if no type hint

--- a/unfazed/route/endpoint.py
+++ b/unfazed/route/endpoint.py
@@ -1,5 +1,6 @@
 import inspect
 import typing as t
+from collections import OrderedDict
 
 from pydantic import BaseModel, ConfigDict, Field, WithJsonSchema, create_model
 from starlette.concurrency import run_in_threadpool
@@ -222,31 +223,28 @@ class EndPointDefinition(BaseModel):
         endpoint = self.endpoint
         type_hints = t.get_type_hints(endpoint, include_extras=True)
 
-        signature = inspect.signature(endpoint)
+        od_all_params: OrderedDict[str, inspect.Parameter] = OrderedDict(
+            inspect.signature(endpoint).parameters
+        )
+        if not od_all_params:
+            raise ValueError(
+                f"endpoint `{self.endpoint_name}` must declare `request: HttpRequest` as the first parameter"
+            )
 
-        # handle endpoint params
+        _, request_param = od_all_params.popitem(last=False)
+        if HttpRequest not in getattr(request_param.annotation, "__mro__", []):
+            raise ValueError(
+                f"request parameter must be the first parameter of endpoint `{self.endpoint_name}`, "
+                f"got `{request_param.name}: {request_param.annotation}`"
+            )
+        self.request_class = t.cast(t.Type[HttpRequest], request_param.annotation)
+
         ret: t.Dict[str, inspect.Parameter] = {}
-        has_request_param = False
-        for index, (args, param) in enumerate(signature.parameters.items()):
+        for args, param in od_all_params.items():
             if param.kind in [
                 inspect.Parameter.VAR_KEYWORD,
                 inspect.Parameter.VAR_POSITIONAL,
             ]:
-                continue
-
-            # skip unfazed request
-            mro = getattr(param.annotation, "__mro__", [])
-            if HttpRequest in mro:
-                if has_request_param:
-                    raise ValueError(
-                        f"multiple request parameters are not supported in endpoint: {self.endpoint_name}"
-                    )
-                if index != 0:
-                    raise ValueError(
-                        f"request parameter must be the first parameter in endpoint: {self.endpoint_name}"
-                    )
-                self.request_class = param.annotation
-                has_request_param = True
                 continue
 
             # raise if no type hint


### PR DESCRIPTION
- Add `request_class` field to `EndPointDefinition`, defaulting to `HttpRequest`
- Detect and store the custom request class from endpoint signature
- Use `endpoint_definition.request_class` in `EndpointHandler.__call__` to instantiate the correct request type
- Enforce that the request parameter must be the first parameter and appear only once
- Add tests: custom request class injection, request-must-be-first, multiple-request-params validation