### PR TITLE
chore(release): prepare v0.0.23 docs and version bump

### DIFF
--- a/docs/en/features/endpoint.md
+++ b/docs/en/features/endpoint.md
@@ -46,6 +46,29 @@ routes = [
 
 Every non-`HttpRequest` parameter in an endpoint signature must declare where its value comes from. You do this with `typing.Annotated[Type, p.Source()]`.
 
+## Custom Request Classes
+
+You can inject a custom request type by subclassing `HttpRequest` and using that subclass as the first endpoint parameter.
+
+```python
+from unfazed.http import HttpRequest, JsonResponse
+
+
+class CustomRequest(HttpRequest):
+    @property
+    def trace_id(self) -> str:
+        return self.headers.get("x-trace-id", "")
+
+
+async def get_trace(request: CustomRequest) -> JsonResponse:
+    return JsonResponse({"trace_id": request.trace_id})
+```
+
+Rules:
+
+- The request parameter must be the first parameter in the endpoint signature.
+- Only one `HttpRequest` or `HttpRequest` subclass parameter is allowed per endpoint.
+
 ### Path Parameters
 
 Extracted from URL path segments. The parameter name must match a `{name}` placeholder in the route path.
@@ -370,6 +393,8 @@ async def good(
 ```
 
 **Cannot mix Json and Form** in the same endpoint. You will get a `ValueError` at startup if you try.
+
+**Custom request parameters must come first.** If you use a custom `HttpRequest` subclass, declare it as the first parameter and only once.
 
 **All parameters require type hints.** Missing type hints raise `TypeHintRequired`.
 

--- a/docs/en/features/request.md
+++ b/docs/en/features/request.md
@@ -26,6 +26,26 @@ async def my_endpoint(request: HttpRequest) -> JsonResponse:
     return JsonResponse({"method": method, "path": path})
 ```
 
+## Custom Request Subclasses
+
+You can extend `HttpRequest` to add project-specific helpers, then type your endpoint with that subclass:
+
+```python
+from unfazed.http import HttpRequest, JsonResponse
+
+
+class CustomRequest(HttpRequest):
+    @property
+    def trace_id(self) -> str:
+        return self.headers.get("x-trace-id", "")
+
+
+async def my_endpoint(request: CustomRequest) -> JsonResponse:
+    return JsonResponse({"trace_id": request.trace_id})
+```
+
+The custom request parameter must be the first parameter in the endpoint signature, and it can only appear once.
+
 ## Available Properties
 
 ### Inherited from Starlette

--- a/docs/en/release-note.md
+++ b/docs/en/release-note.md
@@ -1,3 +1,7 @@
+v0.0.23
+====
+- [issue #120](https://github.com/unfazed-eco/unfazed/issues/120) Endpoint signatures now support injecting a custom `HttpRequest` subclass as the request object.
+
 v0.0.22
 ====
 - [issue #114](https://github.com/unfazed-eco/unfazed/issues/114) change request scope user type

--- a/docs/zh/features/endpoint.md
+++ b/docs/zh/features/endpoint.md
@@ -46,6 +46,29 @@ routes = [
 
 endpoint 签名中每个非 `HttpRequest` 的参数都必须声明其值来源。使用 `typing.Annotated[Type, p.Source()]` 实现。
 
+## 自定义 Request 类
+
+你可以继承 `HttpRequest` 并将该子类作为 endpoint 的第一个参数，从而注入自定义 request 类型。
+
+```python
+from unfazed.http import HttpRequest, JsonResponse
+
+
+class CustomRequest(HttpRequest):
+    @property
+    def trace_id(self) -> str:
+        return self.headers.get("x-trace-id", "")
+
+
+async def get_trace(request: CustomRequest) -> JsonResponse:
+    return JsonResponse({"trace_id": request.trace_id})
+```
+
+规则如下：
+
+- request 参数必须是 endpoint 签名中的第一个参数。
+- 每个 endpoint 只能声明一个 `HttpRequest` 或其子类参数。
+
 ### 路径参数
 
 从 URL 路径段提取。参数名必须与路由路径中的 `{name}` 占位符匹配。
@@ -370,6 +393,8 @@ async def good(
 ```
 
 **不能在同一 endpoint 中混用 Json 和 Form**。尝试时会在启动时抛出 `ValueError`。
+
+**自定义 request 参数必须放在第一个位置。** 如果使用 `HttpRequest` 子类，它必须是第一个参数，且只能声明一次。
 
 **所有参数都需要类型提示。** 缺少类型提示会抛出 `TypeHintRequired`。
 

--- a/docs/zh/features/request.md
+++ b/docs/zh/features/request.md
@@ -26,6 +26,26 @@ async def my_endpoint(request: HttpRequest) -> JsonResponse:
     return JsonResponse({"method": method, "path": path})
 ```
 
+## 自定义 Request 子类
+
+你可以继承 `HttpRequest` 来补充项目自己的辅助属性或方法，然后在 endpoint 中直接标注这个子类：
+
+```python
+from unfazed.http import HttpRequest, JsonResponse
+
+
+class CustomRequest(HttpRequest):
+    @property
+    def trace_id(self) -> str:
+        return self.headers.get("x-trace-id", "")
+
+
+async def my_endpoint(request: CustomRequest) -> JsonResponse:
+    return JsonResponse({"trace_id": request.trace_id})
+```
+
+这个自定义 request 参数必须位于 endpoint 签名的第一个位置，并且只能出现一次。
+
 ## 可用属性
 
 ### 继承自 Starlette

--- a/docs/zh/release-note.md
+++ b/docs/zh/release-note.md
@@ -1,3 +1,8 @@
+v0.0.23
+====
+- [issue #120](https://github.com/unfazed-eco/unfazed/issues/120) endpoint 签名现在支持注入自定义 `HttpRequest` 子类作为请求对象。
+
+
 v0.0.22
 ====
 - [issue #114](https://github.com/unfazed-eco/unfazed/issues/114) change request scope user type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unfazed"
-version = "0.0.22"
+version = "0.0.23"
 description = "Production ready async python web framework"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1210,7 +1210,7 @@ wheels = [
 
 [[package]]
 name = "unfazed"
-version = "0.0.22"
+version = "0.0.23"
 source = { editable = "." }
 dependencies = [
     { name = "aerich" },


### PR DESCRIPTION
- Add v0.0.23 release notes in both Chinese and English
- Document custom HttpRequest subclass injection in the request and endpoint docs
- Bump project version to 0.0.23 in pyproject.toml and uv.lock