### PR TITLE
feat(cache): add DISABLED_CACHED option to bypass cache decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist
 .vscode
 site
 .idea/*
+.deepseek

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   redis:
     image: redis:latest

--- a/docs/en/features/cache.md
+++ b/docs/en/features/cache.md
@@ -56,6 +56,7 @@ The `CACHE` setting is a dictionary where each key is a cache alias (e.g. `"defa
 | `BACKEND` | Dotted import path to the cache backend class. |
 | `LOCATION` | Backend-specific location. For LocMem: a unique name string. For Redis: a connection URL like `redis://localhost:6379/0`. |
 | `OPTIONS` | Dict of backend-specific options (see each backend below). |
+| `DISABLED_CACHED` | `bool`, default `False`. When `True`, the `@cached` decorator will skip caching and always call the function directly for this backend. The backend itself is still instantiated and usable via `caches["alias"]`. |
 
 You can define as many named caches as you need and access them by alias:
 
@@ -337,6 +338,22 @@ Calling that function with `force_update=...` may still raise a `TypeError` from
 - The decorator only uses keyword arguments for the cache key. Positional arguments are ignored (a warning is emitted if you pass them).
 - `@cached` validates the function signature at decoration time and emits warnings for unsupported/ambiguous `force_update` usage (for example missing `force_update`/`**kwargs`, or non-`bool` annotation).
 - `@cached` does not enforce a runtime boolean type check for `force_update`; runtime behavior follows Python truthiness.
+
+**Disabling caching per backend** — set `DISABLED_CACHED: True` in the backend config to make the `@cached` decorator skip caching entirely for that backend. This is useful during development or testing when you want functions to always execute without caching:
+
+```python
+# settings.py
+UNFAZED_SETTINGS = {
+    "CACHE": {
+        "default": {
+            "BACKEND": "unfazed.cache.backends.locmem.LocMemCache",
+            "LOCATION": "default_cache",
+            "OPTIONS": {"MAX_ENTRIES": 1000},
+            "DISABLED_CACHED": True,  # @cached(using="default") will always call the function
+        },
+    },
+}
+```
 
 ## Custom Serializers & Compressors
 

--- a/tests/test_cache/test_disabled_cached.py
+++ b/tests/test_cache/test_disabled_cached.py
@@ -1,0 +1,126 @@
+import typing as t
+
+import pytest
+
+from unfazed.cache import cached, caches
+from unfazed.cache.backends.locmem import LocMemCache
+from unfazed.conf import UnfazedSettings
+from unfazed.core import Unfazed
+
+
+_Settings = {
+    "DEBUG": True,
+    "PROJECT_NAME": "test_disabled_cached",
+    "CACHE": {
+        "default": {
+            "BACKEND": "unfazed.cache.backends.locmem.LocMemCache",
+            "LOCATION": "test_disabled_default",
+            "OPTIONS": {"MAX_ENTRIES": 1000},
+        },
+        "disabled": {
+            "BACKEND": "unfazed.cache.backends.locmem.LocMemCache",
+            "LOCATION": "test_disabled_backend",
+            "OPTIONS": {"MAX_ENTRIES": 1000},
+            "DISABLED_CACHED": True,
+        },
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+async def setup_app() -> t.AsyncGenerator[None, None]:
+    unfazed = Unfazed(settings=UnfazedSettings.model_validate(_Settings))
+    await unfazed.setup()
+    yield
+    caches.clear()
+
+
+async def test_disabled_cached_skips_cache_for_async_func() -> None:
+    """DISABLED_CACHED=True should bypass cache, calling the function every time."""
+    call_count = 0
+
+    @cached(using="disabled", include=["x"])
+    async def fn(x: int) -> int:
+        nonlocal call_count
+        call_count += 1
+        return call_count
+
+    assert await fn(x=1) == 1
+    assert await fn(x=1) == 2  # not cached, called again
+
+
+async def test_disabled_cached_skips_cache_for_sync_func() -> None:
+    """DISABLED_CACHED=True should also work for sync functions."""
+    call_count = 0
+
+    @cached(using="disabled", include=["x"])
+    def fn(x: int) -> int:
+        nonlocal call_count
+        call_count += 1
+        return call_count
+
+    assert await fn(x=1) == 1
+    assert await fn(x=1) == 2
+
+
+async def test_enabled_cached_still_works() -> None:
+    """Default backend (DISABLED_CACHED=False) should still cache normally."""
+    call_count = 0
+
+    @cached(using="default", include=["x"])
+    async def fn(x: int) -> int:
+        nonlocal call_count
+        call_count += 1
+        return call_count
+
+    assert await fn(x=1) == 1
+    assert await fn(x=1) == 1  # cached, same result
+
+
+async def test_disabled_cached_different_params() -> None:
+    """DISABLED_CACHED=True should call function every time, even with different params."""
+    call_count = 0
+
+    @cached(using="disabled", include=["x"])
+    async def fn(x: int) -> int:
+        nonlocal call_count
+        call_count += 1
+        return call_count
+
+    assert await fn(x=1) == 1
+    assert await fn(x=2) == 2
+    assert await fn(x=1) == 3  # not cached, called again
+
+
+async def test_no_disabled_cached_field_defaults_to_enabled() -> None:
+    """When DISABLED_CACHED is not set in config, caching should work normally."""
+    # "default" backend in _Settings has no DISABLED_CACHED field
+    call_count = 0
+
+    @cached(using="default", include=["x"])
+    async def fn(x: int) -> int:
+        nonlocal call_count
+        call_count += 1
+        return call_count
+
+    assert await fn(x=1) == 1
+    assert await fn(x=1) == 1  # cached
+    assert await fn(x=2) == 2  # different key, called again
+    assert await fn(x=2) == 2  # cached
+
+
+async def test_disabled_cached_when_cache_conf_not_found() -> None:
+    """When using an alias not in settings.CACHE, should fall through to normal cache path."""
+    caches["unlisted"] = LocMemCache(location="unlisted", options={"MAX_ENTRIES": 100})
+
+    call_count = 0
+
+    @cached(using="unlisted", include=["x"])
+    async def fn(x: int) -> int:
+        nonlocal call_count
+        call_count += 1
+        return call_count
+
+    # alias not in settings.CACHE -> cache_conf is None -> caching still works
+    assert await fn(x=1) == 1
+    assert await fn(x=1) == 1  # cached

--- a/unfazed/cache/decorators.py
+++ b/unfazed/cache/decorators.py
@@ -2,6 +2,7 @@ import inspect
 import typing as t
 import warnings
 from functools import wraps
+from unfazed.conf import settings
 
 from unfazed.concurrency import run_in_threadpool
 
@@ -124,6 +125,13 @@ def cached(
                     UserWarning,
                     stacklevel=2,
                 )
+                
+            cache_conf = (settings["UNFAZED_SETTINGS"].CACHE or {}).get(using)
+            if cache_conf and cache_conf.DISABLED_CACHED:
+                if inspect.iscoroutinefunction(func):
+                    return await func(*args, **kwargs)
+                else:
+                    return await run_in_threadpool(func, *args, **kwargs)
 
             prefix = f"{func.__module__}:{func.__qualname__}"
             if include:

--- a/unfazed/schema/cache.py
+++ b/unfazed/schema/cache.py
@@ -9,6 +9,7 @@ class Cache(BaseModel):
     BACKEND: CanBeImported
     LOCATION: t.List[str] | str | None = None
     OPTIONS: t.Dict[str, t.Any] | None = None
+    DISABLED_CACHED: bool = False
 
 
 class LocOptions(BaseModel):


### PR DESCRIPTION
Add a DISABLED_CACHED config field to Cache schema, allowing per-backend control over whether the @cached decorator uses caching or calls the function directly. The setting is read from settings at runtime.