### PR TITLE
Improve session cookie lifecycle and stale CacheSession handling

### DIFF
--- a/docs/en/features/contrib/session.md
+++ b/docs/en/features/contrib/session.md
@@ -68,7 +68,23 @@ Session settings are registered under `UNFAZED_CONTRIB_SESSION_SETTINGS`:
 | `COOKIE_HTTPONLY` | `bool` | `True` | Prevent JavaScript access to the cookie. |
 | `COOKIE_SAMESITE` | `"lax" \| "strict" \| "none"` | `"lax"` | SameSite cookie attribute. |
 | `COOKIE_MAX_AGE` | `int` | `604800` (7 days) | Cookie lifetime in seconds. |
+| `COOKIE_EXPIRE_AT_BROWSER_CLOSE` | `bool` | `False` | If `True`, write the session cookie without `Max-Age` or `Expires`, so the browser treats it as a session cookie. |
 | `CACHE_ALIAS` | `str` | `"default"` | Cache backend alias (only used by `CacheSession`). |
+
+### Browser-session cookies
+
+Set `COOKIE_EXPIRE_AT_BROWSER_CLOSE` to `True` when the browser should not persist the session cookie after the browser session ends:
+
+```python
+UNFAZED_CONTRIB_SESSION_SETTINGS = {
+    "SECRET": "my-secret",
+    "COOKIE_EXPIRE_AT_BROWSER_CLOSE": True,
+}
+```
+
+With this option enabled, normal session updates omit `Max-Age` and `Expires` in the `Set-Cookie` header. `COOKIE_MAX_AGE` still applies to the session data itself: `SigningSession` uses it to validate the signed cookie timestamp, and `CacheSession` uses it as the cache TTL.
+
+When a session is flushed or becomes empty, Unfazed still sends `Max-Age=0` and an expired `Expires` value so the browser removes the cookie immediately.
 
 ## Backends
 
@@ -185,6 +201,7 @@ Abstract base class for session backends. Implements dict-like access (`[]`, `in
 | `async delete()` | Clear all session data. |
 | `async flush()` | Alias for `delete()`. |
 | `get_max_age()` | Return `cookie_max_age` from settings. |
+| `get_cookie_max_age()` | Return the cookie `Max-Age`, or `None` when browser-session cookies are enabled. |
 | `generate_session_key()` | (abstract) Generate a new session key. |
 | `async save()` | (abstract) Persist session data. |
 | `async load()` | (abstract) Load session data. |

--- a/docs/en/features/contrib/session.md
+++ b/docs/en/features/contrib/session.md
@@ -140,8 +140,9 @@ UNFAZED_SETTINGS = {
 **How it works:**
 
 1. On `load()`: the session key from the cookie is used to fetch data from the cache.
-2. On `save()`: a new session key is generated (if needed) and data is stored in the cache with TTL equal to `COOKIE_MAX_AGE`.
-3. If the session is empty on save, the cache entry is deleted.
+2. If the cache entry is missing or expired, the session key is reset, the session is emptied, and the stale browser cookie is removed on the response.
+3. On `save()`: a new session key is generated (if needed) and data is stored in the cache with TTL equal to `COOKIE_MAX_AGE`.
+4. If the session is empty on save, the cache entry is deleted.
 
 **Trade-offs:**
 

--- a/docs/en/release-note.md
+++ b/docs/en/release-note.md
@@ -2,6 +2,7 @@ v0.0.23
 ====
 - [issue #120](https://github.com/unfazed-eco/unfazed/issues/120) Endpoint signatures now support injecting a custom `HttpRequest` subclass as the request object.
 - Add `COOKIE_EXPIRE_AT_BROWSER_CLOSE` for session cookies and fix expired session cookie header formatting.
+- Reset `CacheSession` when the cache entry is missing so stale session cookies are cleared.
 
 v0.0.22
 ====

--- a/docs/en/release-note.md
+++ b/docs/en/release-note.md
@@ -1,6 +1,7 @@
 v0.0.23
 ====
 - [issue #120](https://github.com/unfazed-eco/unfazed/issues/120) Endpoint signatures now support injecting a custom `HttpRequest` subclass as the request object.
+- Add `COOKIE_EXPIRE_AT_BROWSER_CLOSE` for session cookies and fix expired session cookie header formatting.
 
 v0.0.22
 ====

--- a/docs/zh/features/contrib/session.md
+++ b/docs/zh/features/contrib/session.md
@@ -68,7 +68,23 @@ Session 设置注册在 `UNFAZED_CONTRIB_SESSION_SETTINGS` 下：
 | `COOKIE_HTTPONLY` | `bool` | `True` | 禁止 JavaScript 访问 cookie。 |
 | `COOKIE_SAMESITE` | `"lax" \| "strict" \| "none"` | `"lax"` | SameSite cookie 属性。 |
 | `COOKIE_MAX_AGE` | `int` | `604800`（7 天） | cookie 生命周期（秒）。 |
+| `COOKIE_EXPIRE_AT_BROWSER_CLOSE` | `bool` | `False` | 若为 `True`，写入 session cookie 时不设置 `Max-Age` 或 `Expires`，让浏览器把它视为会话 cookie。 |
 | `CACHE_ALIAS` | `str` | `"default"` | 缓存后端别名（仅 `CacheSession` 使用）。 |
+
+### 浏览器会话 cookie
+
+当你不希望浏览器在浏览器会话结束后继续持久保存 session cookie 时，可以设置 `COOKIE_EXPIRE_AT_BROWSER_CLOSE`：
+
+```python
+UNFAZED_CONTRIB_SESSION_SETTINGS = {
+    "SECRET": "my-secret",
+    "COOKIE_EXPIRE_AT_BROWSER_CLOSE": True,
+}
+```
+
+开启后，正常 session 更新生成的 `Set-Cookie` 头不会包含 `Max-Age` 或 `Expires`。`COOKIE_MAX_AGE` 仍然会约束 session 数据本身：`SigningSession` 用它校验签名 cookie 的时间戳，`CacheSession` 用它作为缓存 TTL。
+
+当 session 被 flush 或变为空时，Unfazed 仍会发送 `Max-Age=0` 和已过期的 `Expires` 值，让浏览器立即删除 cookie。
 
 ## 后端
 
@@ -185,6 +201,7 @@ session 后端的抽象基类。对内部 `_session` 字典实现类 dict 的访
 | `async delete()` | 清除所有 session 数据。 |
 | `async flush()` | `delete()` 的别名。 |
 | `get_max_age()` | 从设置中返回 `cookie_max_age`。 |
+| `get_cookie_max_age()` | 返回 cookie 的 `Max-Age`；当启用浏览器会话 cookie 时返回 `None`。 |
 | `generate_session_key()` | （抽象）生成新的 session 键。 |
 | `async save()` | （抽象）持久化 session 数据。 |
 | `async load()` | （抽象）加载 session 数据。 |

--- a/docs/zh/features/contrib/session.md
+++ b/docs/zh/features/contrib/session.md
@@ -140,8 +140,9 @@ UNFAZED_SETTINGS = {
 **工作原理：**
 
 1. `load()` 时：使用 cookie 中的 session 键从缓存获取数据。
-2. `save()` 时：生成新的 session 键（如需要）并将数据存入缓存，TTL 等于 `COOKIE_MAX_AGE`。
-3. 若 save 时 session 为空，则删除缓存条目。
+2. 若缓存条目不存在或已过期，则重置 session 键、清空 session，并在响应中删除浏览器里的旧 cookie。
+3. `save()` 时：生成新的 session 键（如需要）并将数据存入缓存，TTL 等于 `COOKIE_MAX_AGE`。
+4. 若 save 时 session 为空，则删除缓存条目。
 
 **权衡：**
 

--- a/docs/zh/release-note.md
+++ b/docs/zh/release-note.md
@@ -1,6 +1,7 @@
 v0.0.23
 ====
 - [issue #120](https://github.com/unfazed-eco/unfazed/issues/120) endpoint 签名现在支持注入自定义 `HttpRequest` 子类作为请求对象。
+- Session cookie 新增 `COOKIE_EXPIRE_AT_BROWSER_CLOSE` 配置，并修复过期 session cookie header 格式。
 
 
 v0.0.22

--- a/docs/zh/release-note.md
+++ b/docs/zh/release-note.md
@@ -2,6 +2,7 @@ v0.0.23
 ====
 - [issue #120](https://github.com/unfazed-eco/unfazed/issues/120) endpoint 签名现在支持注入自定义 `HttpRequest` 子类作为请求对象。
 - Session cookie 新增 `COOKIE_EXPIRE_AT_BROWSER_CLOSE` 配置，并修复过期 session cookie header 格式。
+- `CacheSession` 在缓存条目不存在时会重置 session，并清理浏览器中的旧 session cookie。
 
 
 v0.0.22

--- a/tests/test_contrib/test_session/test_default_client.py
+++ b/tests/test_contrib/test_session/test_default_client.py
@@ -55,7 +55,7 @@ async def test_default() -> None:
     await session2.save()
     assert bool(session2) is False
     assert session2.modified is False
-    assert session2.get_expiry_age() == "expires=Thu, 01 Jan 1970 00:00:00 GMT; "
+    assert session2.get_expiry_age() == "Thu, 01 Jan 1970 00:00:00 GMT"
 
     # failed case
     session3 = SigningSession(

--- a/tests/test_contrib/test_session/test_session_middleware.py
+++ b/tests/test_contrib/test_session/test_session_middleware.py
@@ -1,4 +1,3 @@
-import os
 import uuid
 
 from unfazed.conf import UnfazedSettings, settings
@@ -8,14 +7,13 @@ from unfazed.http import HttpRequest, HttpResponse, JsonResponse
 from unfazed.route import Route
 from unfazed.test import Requestfactory
 
-HOST = os.getenv("REDIS_HOST", "redis")
 UNFAZED_SETTINGS = {
     "PROJECT": "test_middleware",
     "MIDDLEWARE": ["unfazed.contrib.session.middleware.SessionMiddleware"],
     "CACHE": {
         "default": {
-            "BACKEND": "unfazed.cache.backends.redis.SerializerBackend",
-            "LOCATION": f"redis://{HOST}:6379",
+            "BACKEND": "unfazed.cache.backends.locmem.LocMemCache",
+            "LOCATION": "test_middleware",
             "OPTIONS": {
                 "PREFIX": "test_middleware",
             },
@@ -36,6 +34,13 @@ CACHE_SESSION_SETTINGS = {
     "COOKIE_SECURE": True,
     "CACHE_ALIAS": "default",
     "ENGINE": "unfazed.contrib.session.backends.cache.CacheSession",
+}
+
+BROWSER_CLOSE_SESSION_SETTINGS = {
+    "SECRET": uuid.uuid4().hex,
+    "COOKIE_DOMAIN": "unfazed.com",
+    "COOKIE_SECURE": True,
+    "COOKIE_EXPIRE_AT_BROWSER_CLOSE": True,
 }
 
 
@@ -73,7 +78,41 @@ ROUTES = [
 ]
 
 
-async def _test_engine(unfazed: Unfazed, session_setting: SessionSettings) -> None:
+async def _build_unfazed() -> Unfazed:
+    unfazed = Unfazed(
+        settings=UnfazedSettings.model_validate(UNFAZED_SETTINGS),
+        routes=ROUTES,
+        silent=True,
+    )
+    await unfazed.setup()
+    return unfazed
+
+
+def _assert_persistent_session_cookie(header_value: str | None) -> None:
+    assert header_value is not None
+    assert "Max-Age=604800" in header_value
+    assert "expires=" not in header_value.lower()
+
+
+def _assert_browser_close_session_cookie(header_value: str | None) -> None:
+    assert header_value is not None
+    assert "Max-Age" not in header_value
+    assert "expires=" not in header_value.lower()
+
+
+def _assert_deleted_session_cookie(header_value: str | None) -> None:
+    assert header_value is not None
+    assert "Max-Age=0" in header_value
+    assert "expires=Thu, 01 Jan 1970 00:00:00 GMT" in header_value
+    assert "expires=expires=" not in header_value
+
+
+async def _test_engine(
+    unfazed: Unfazed,
+    session_setting: SessionSettings,
+    *,
+    expire_at_browser_close: bool = False,
+) -> None:
     settings["UNFAZED_CONTRIB_SESSION_SETTINGS"] = session_setting
 
     async with Requestfactory(unfazed, base_url="https://unfazed.com") as request:
@@ -81,6 +120,10 @@ async def _test_engine(unfazed: Unfazed, session_setting: SessionSettings) -> No
         resp = await request.get("/login")
         assert resp.status_code == 200
         assert resp.text == "ok"
+        if expire_at_browser_close:
+            _assert_browser_close_session_cookie(resp.headers.get("set-cookie"))
+        else:
+            _assert_persistent_session_cookie(resp.headers.get("set-cookie"))
 
         # read
         resp = await request.get("/read")
@@ -91,6 +134,10 @@ async def _test_engine(unfazed: Unfazed, session_setting: SessionSettings) -> No
         resp = await request.get("/update")
         assert resp.status_code == 200
         assert resp.text == "ok"
+        if expire_at_browser_close:
+            _assert_browser_close_session_cookie(resp.headers.get("set-cookie"))
+        else:
+            _assert_persistent_session_cookie(resp.headers.get("set-cookie"))
 
         # read
         resp = await request.get("/read")
@@ -101,6 +148,7 @@ async def _test_engine(unfazed: Unfazed, session_setting: SessionSettings) -> No
         resp = await request.get("/logout")
         assert resp.status_code == 200
         assert resp.text == "ok"
+        _assert_deleted_session_cookie(resp.headers.get("set-cookie"))
 
         # read
         resp = await request.get("/read")
@@ -109,13 +157,18 @@ async def _test_engine(unfazed: Unfazed, session_setting: SessionSettings) -> No
 
 
 async def test_middleware() -> None:
-    unfazed = Unfazed(
-        settings=UnfazedSettings.model_validate((UNFAZED_SETTINGS)), routes=ROUTES
-    )
-    await unfazed.setup()
     await _test_engine(
-        unfazed, SessionSettings.model_validate(DEFAULT_SESSION_SETTINGS)
+        await _build_unfazed(),
+        SessionSettings.model_validate(BROWSER_CLOSE_SESSION_SETTINGS),
+        expire_at_browser_close=True,
     )
 
-    cache_session_setting = SessionSettings.model_validate(CACHE_SESSION_SETTINGS)
-    await _test_engine(unfazed, cache_session_setting)
+    await _test_engine(
+        await _build_unfazed(),
+        SessionSettings.model_validate(DEFAULT_SESSION_SETTINGS),
+    )
+
+    await _test_engine(
+        await _build_unfazed(),
+        SessionSettings.model_validate(CACHE_SESSION_SETTINGS)
+    )

--- a/tests/test_contrib/test_session/test_session_middleware.py
+++ b/tests/test_contrib/test_session/test_session_middleware.py
@@ -1,6 +1,8 @@
 import uuid
 
+from unfazed.cache import caches
 from unfazed.conf import UnfazedSettings, settings
+from unfazed.contrib.session.backends.cache import CacheSession
 from unfazed.contrib.session.settings import SessionSettings
 from unfazed.core import Unfazed
 from unfazed.http import HttpRequest, HttpResponse, JsonResponse
@@ -170,5 +172,44 @@ async def test_middleware() -> None:
 
     await _test_engine(
         await _build_unfazed(),
-        SessionSettings.model_validate(CACHE_SESSION_SETTINGS)
+        SessionSettings.model_validate(CACHE_SESSION_SETTINGS),
     )
+
+
+async def test_cache_session_resets_when_cache_misses() -> None:
+    await _build_unfazed()
+    session = CacheSession(
+        SessionSettings.model_validate(CACHE_SESSION_SETTINGS),
+        session_key="missing-session-key",
+    )
+
+    await session.load()
+
+    assert session.session_key is None
+    assert session._session == {}
+    assert session.modified is True
+
+    await session.save()
+
+    assert session.session_key is None
+
+
+async def test_cache_session_deletes_stale_cookie_when_cache_misses() -> None:
+    settings["UNFAZED_CONTRIB_SESSION_SETTINGS"] = SessionSettings.model_validate(
+        CACHE_SESSION_SETTINGS
+    )
+
+    async with Requestfactory(
+        await _build_unfazed(),
+        base_url="https://unfazed.com",
+    ) as request:
+        resp = await request.get("/login")
+        assert resp.status_code == 200
+        _assert_persistent_session_cookie(resp.headers.get("set-cookie"))
+
+        await caches["default"].clear()
+
+        resp = await request.get("/read")
+        assert resp.status_code == 200
+        assert resp.json() == {}
+        _assert_deleted_session_cookie(resp.headers.get("set-cookie"))

--- a/unfazed/contrib/session/backends/base.py
+++ b/unfazed/contrib/session/backends/base.py
@@ -51,12 +51,17 @@ class SessionBase(ABC):
     def get_max_age(self) -> int:
         return self.setting.cookie_max_age
 
+    def get_cookie_max_age(self) -> int | None:
+        if self.setting.cookie_expire_at_browser_close:
+            return None
+        return self.setting.cookie_max_age
+
     def get_expiry_age(self) -> str | None:
         """
-        use max age to control the expiry of the cookie
+        Return an expired HTTP date when the session cookie should be removed.
         """
         if not self._session:
-            return "expires=Thu, 01 Jan 1970 00:00:00 GMT; "
+            return "Thu, 01 Jan 1970 00:00:00 GMT"
         return None
 
     async def flush(self) -> None:

--- a/unfazed/contrib/session/backends/cache.py
+++ b/unfazed/contrib/session/backends/cache.py
@@ -39,14 +39,15 @@ class CacheSession(SessionBase):
         return f"{self.PREFIX}{timestamp}:{uuid_hex_str1}:{uuid_hex_str2}"
 
     async def save(self) -> None:
+        if not self._session:
+            if self.session_key:
+                await self.client.delete(self.session_key)
+            return
+
         if not self.session_key:
             self.session_key = self.generate_session_key()
 
-        if not self._session:
-            await self.client.delete(self.session_key)
-
-        else:
-            await self.client.set(self.session_key, self._session, self.get_max_age())
+        await self.client.set(self.session_key, self._session, self.get_max_age())
 
     async def load(self) -> None:
         if not self.session_key:
@@ -56,8 +57,10 @@ class CacheSession(SessionBase):
         ret = await self.client.get(self.session_key)
 
         # expired or not found
-        if not ret:
+        if ret is None:
+            self.session_key = None
             self._session = {}
+            self.modified = True
+            return
 
-        else:
-            self._session = ret
+        self._session = ret

--- a/unfazed/contrib/session/middleware.py
+++ b/unfazed/contrib/session/middleware.py
@@ -44,12 +44,12 @@ class SessionMiddleware:
                 if session_store.modified:
                     await session_store.save()
 
-                    # if session is empty, delete the cookie
+                    # set or update the cookie if session is not empty, or delete the cookie
                     if session_store:
                         header_value = build_cookie(
                             self.setting.cookie_name,
                             t.cast(str, session_store.session_key),
-                            max_age=self.setting.cookie_max_age,
+                            max_age=session_store.get_cookie_max_age(),
                             expires=session_store.get_expiry_age(),
                             path=self.setting.cookie_path,
                             domain=self.setting.cookie_domain,

--- a/unfazed/contrib/session/settings.py
+++ b/unfazed/contrib/session/settings.py
@@ -27,6 +27,10 @@ class SessionSettings(BaseModel):
         alias="COOKIE_SAMESITE",
     )
     cookie_max_age: int = Field(default=60 * 60 * 24 * 7, alias="COOKIE_MAX_AGE")
+    cookie_expire_at_browser_close: bool = Field(
+        default=False,
+        alias="COOKIE_EXPIRE_AT_BROWSER_CLOSE",
+    )
 
     # If both Expires and Max-Age are set, Max-Age has precedence.
     # => so unfazed ignore `expires`


### PR DESCRIPTION
## Summary

This PR improves session cookie lifecycle handling in `unfazed.contrib.session`.

- Add `COOKIE_EXPIRE_AT_BROWSER_CLOSE` to support browser-session cookies.
- Keep `COOKIE_MAX_AGE` as the session data lifetime for signed-cookie validation and cache TTL.
- Fix expired session cookie formatting so `Expires` is emitted correctly.
- Reset `CacheSession` when the cache entry is missing or expired.
- Clear stale browser cookies when a cached session can no longer be loaded.
- Update English and Chinese session documentation and release notes.

## Behavior Changes

When `COOKIE_EXPIRE_AT_BROWSER_CLOSE=True`, normal session updates no longer include `Max-Age` or `Expires` in the `Set-Cookie` header, allowing browsers to treat the cookie as a session cookie.

For `CacheSession`, if the session key from the browser cookie no longer exists in the cache, the session key is reset, the in-memory session is cleared, and the session is marked as modified so middleware removes the stale browser cookie in the response.