### PR TITLE
feat: add DummyCache async no-op cache backend

### DIFF
--- a/docs/en/features/cache.md
+++ b/docs/en/features/cache.md
@@ -95,6 +95,25 @@ A simple in-process cache backed by an `OrderedDict`. Good for development and s
 }
 ```
 
+### DummyCache — No-Op
+
+A no-op backend that accepts any method call but performs no actual operations. Useful for testing and development when you want to disable caching without changing application code. All read operations return defaults, all write operations are silently ignored, and any unknown method is proxied to a no-op.
+
+**Backend path:** `unfazed.cache.backends.dummy.DummyCache`
+
+**Options:** None. All options are ignored.
+
+**Configuration example:**
+
+```python
+"CACHE": {
+    "default": {
+        "BACKEND": "unfazed.cache.backends.dummy.DummyCache",
+        "LOCATION": "dummy",
+    },
+}
+```
+
 ### DefaultBackend — Raw Redis
 
 A thin wrapper around `redis.asyncio.Redis` that adds key prefixing and connection management. All standard Redis commands are available through attribute proxying — you call Redis methods directly on the backend instance.
@@ -432,6 +451,24 @@ In-process cache with automatic eviction.
 - `async clear() -> None`
 - `async close() -> None`
 - `make_key(key: str, version: int | None = None) -> str`
+
+### DummyCache
+
+```python
+class DummyCache(location: str, options: Dict[str, Any] | None = None)
+```
+
+No-op backend that proxies any method call to an async no-op. Never stores or retrieves data.
+
+- `async get(key: str, default: Any = None, version: int | None = None) -> Any`: Always returns `default`.
+- `async set(key: str, value: Any, timeout: float | None = None, version: int | None = None) -> None`: No-op.
+- `async delete(key: str, version: int | None = None) -> bool`: Always returns `False`.
+- `async has_key(key: str, version: int | None = None) -> bool`: Always returns `False`.
+- `async incr(key: str, delta: int = 1, version: int | None = None) -> int`: Always returns `0`.
+- `async decr(key: str, delta: int = 1, version: int | None = None) -> int`: Always returns `0`.
+- `async clear() -> None`: No-op.
+- `async close() -> None`: Sets the `closed` flag to `True`.
+- Any other method is proxied via `__getattr__` to an async no-op returning `None`.
 
 ### DefaultBackend
 

--- a/docs/zh/features/cache.md
+++ b/docs/zh/features/cache.md
@@ -95,6 +95,25 @@ sessions = caches["sessions"]
 }
 ```
 
+### DummyCache — 无操作
+
+一个无操作后端，接受任意方法调用但不执行实际操作。适用于在测试和开发中禁用缓存而无需修改应用代码。所有读操作返回默认值，所有写操作静默忽略，任意未知方法都会被代理到无操作函数。
+
+**后端路径：** `unfazed.cache.backends.dummy.DummyCache`
+
+**选项：** 无。所有选项均被忽略。
+
+**配置示例：**
+
+```python
+"CACHE": {
+    "default": {
+        "BACKEND": "unfazed.cache.backends.dummy.DummyCache",
+        "LOCATION": "dummy",
+    },
+}
+```
+
 ### DefaultBackend — 原生 Redis
 
 `redis.asyncio.Redis` 的轻量封装，增加键前缀和连接管理。所有标准 Redis 命令通过属性代理可用 —— 你直接在后端实例上调用 Redis 方法。
@@ -432,6 +451,24 @@ class LocMemCache(location: str, options: Dict[str, Any] | None = None)
 - `async clear() -> None`
 - `async close() -> None`
 - `make_key(key: str, version: int | None = None) -> str`
+
+### DummyCache
+
+```python
+class DummyCache(location: str, options: Dict[str, Any] | None = None)
+```
+
+无操作后端，将任意方法调用代理到异步无操作函数。永不存储或检索数据。
+
+- `async get(key: str, default: Any = None, version: int | None = None) -> Any`：始终返回 `default`。
+- `async set(key: str, value: Any, timeout: float | None = None, version: int | None = None) -> None`：无操作。
+- `async delete(key: str, version: int | None = None) -> bool`：始终返回 `False`。
+- `async has_key(key: str, version: int | None = None) -> bool`：始终返回 `False`。
+- `async incr(key: str, delta: int = 1, version: int | None = None) -> int`：始终返回 `0`。
+- `async decr(key: str, delta: int = 1, version: int | None = None) -> int`：始终返回 `0`。
+- `async clear() -> None`：无操作。
+- `async close() -> None`：将 `closed` 标志设为 `True`。
+- 其他任意方法通过 `__getattr__` 代理到异步无操作函数，返回 `None`。
 
 ### DefaultBackend
 

--- a/tests/test_cache/test_backends/test_dummy.py
+++ b/tests/test_cache/test_backends/test_dummy.py
@@ -1,0 +1,64 @@
+import typing as t
+
+from unfazed.cache import caches
+from unfazed.cache.backends.dummy import DummyCache
+from unfazed.conf import UnfazedSettings
+from unfazed.core import Unfazed
+
+_Settings = {
+    "DEBUG": True,
+    "PROJECT_NAME": "test_dummy_cache",
+    "CACHE": {
+        "dummy1": {
+            "BACKEND": "unfazed.cache.backends.dummy.DummyCache",
+            "LOCATION": "unfazed_dummy1",
+        },
+    },
+}
+
+
+async def test_dummy_cache() -> None:
+    unfazed = Unfazed(settings=UnfazedSettings.model_validate(_Settings))
+    await unfazed.setup()
+
+    cache: DummyCache = t.cast(DummyCache, caches["dummy1"])
+
+    # test get always returns default
+    assert await cache.get("foo") is None
+    assert await cache.get("foo", default="bar") == "bar"
+
+    # test set is a no-op
+    await cache.set("foo", "bar")
+    assert await cache.get("foo") is None
+
+    # test has_key always returns False
+    assert await cache.has_key("foo") is False
+    await cache.set("foo", "bar")
+    assert await cache.has_key("foo") is False
+
+    # test incr returns 0 (no-op)
+    assert await cache.incr("counter") == 0
+
+    # test decr returns 0 (no-op)
+    assert await cache.decr("counter") == 0
+
+    # test delete always returns False
+    assert await cache.delete("foo") is False
+    await cache.set("foo", "bar")
+    assert await cache.delete("foo") is False
+
+    # test clear is a no-op
+    await cache.set("foo", "bar")
+    await cache.clear()
+    assert await cache.get("foo") is None
+
+    # test proxied method (no-op)
+    result = await cache.mget(["key1", "key2"])  # type: ignore[attr-defined]
+    assert result is None
+
+    result = await cache.any_unknown_method("arg1", kw="val")  # type: ignore[attr-defined]
+    assert result is None
+
+    # test close
+    await cache.close()
+    assert cache.closed is True

--- a/unfazed/cache/backends/dummy.py
+++ b/unfazed/cache/backends/dummy.py
@@ -1,0 +1,75 @@
+import typing as t
+
+
+async def _noop(*args: t.Any, **kwargs: t.Any) -> None:
+    return None
+
+
+class DummyCache:
+    """
+    Dummy cache backend that proxies any method call without producing actual effects.
+
+    This is useful for development and testing when you want to disable caching
+    without changing your application code. All method calls are accepted but
+    produce no side effects, and return sensible no-op defaults.
+
+    Parameters:
+        location (str): Unique identifier for this cache instance
+        options (Dict[str, Any] | None): Configuration options (ignored)
+
+    Usage:
+        ```python
+        from unfazed.cache import caches
+
+        cache: DummyCache = caches["default"]
+
+        # All operations are no-ops
+        await cache.set("key", "value")       # Does nothing
+        value = await cache.get("key")         # Returns None
+        await cache.hset("hash", "f", "v")     # Proxied, no-op
+        ```
+    """
+
+    def __init__(
+        self, location: str, options: t.Dict[str, t.Any] | None = None
+    ) -> None:
+        self.location = location
+        self.closed = False
+
+    async def get(
+        self,
+        key: str,
+        default: t.Any | None = None,
+        version: int | None = None,
+    ) -> t.Any:
+        return default
+
+    async def set(
+        self,
+        key: str,
+        value: t.Any,
+        timeout: float | None = None,
+        version: int | None = None,
+    ) -> None:
+        return None
+
+    async def incr(self, key: str, delta: int = 1, version: int | None = None) -> int:
+        return 0
+
+    async def decr(self, key: str, delta: int = 1, version: int | None = None) -> int:
+        return 0
+
+    async def has_key(self, key: str, version: int | None = None) -> bool:
+        return False
+
+    async def delete(self, key: str, version: int | None = None) -> bool:
+        return False
+
+    async def clear(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        self.closed = True
+
+    def __getattr__(self, name: str) -> t.Any:
+        return _noop

--- a/unfazed/type/cache.py
+++ b/unfazed/type/cache.py
@@ -1,6 +1,7 @@
 import typing as t
 
 if t.TYPE_CHECKING:
+    from unfazed.cache.backends.dummy import DummyCache  # pragma: no cover
     from unfazed.cache.backends.locmem import LocMemCache  # pragma: no cover
     from unfazed.cache.backends.redis.defaultclient import (
         DefaultBackend,  # pragma: no cover
@@ -18,5 +19,6 @@ class CacheOptions(t.TypedDict):
 
 
 CacheBackend = t.TypeVar(
-    "CacheBackend", bound=t.Union["LocMemCache", "DefaultBackend", "SerializerBackend"]
+    "CacheBackend",
+    bound=t.Union["LocMemCache", "DefaultBackend", "SerializerBackend", "DummyCache"],
 )


### PR DESCRIPTION
- Add DummyCache backend that proxies any method call to async no-op
- All read ops return defaults, write ops silently ignored
- __getattr__ proxies unknown methods to async no-op
- Update CacheBackend TypeVar to include DummyCache
- Add tests and bilingual docs (en/zh)

fix #133 