### PR TITLE
update-tortoise-orm

### DIFF
--- a/examples/myprj/src/backend/entry/settings/__init__.py
+++ b/examples/myprj/src/backend/entry/settings/__init__.py
@@ -26,26 +26,39 @@ UNFAZED_SETTINGS = {
     "PROJECT_NAME": PROJECT_NAME,
     "ROOT_URLCONF": "entry.routes",
     "INSTALLED_APPS": ["unfazed.contrib.admin", "unfazed.contrib.auth"],
-    # "DATABASE": {
-    #     "CONNECTIONS": {
-    #         "default": {
-    #             "ENGINE": "tortoise.backends.mysql",
-    #             "CREDENTIALS": {
-    #                 "HOST": "mysql",
-    #                 "PORT": 3306,
-    #                 "USER": "root",
-    #                 "PASSWORD": "app",
-    #                 "DATABASE": "app",
-    #             },
-    #         }
-    #     }
-    # },
-    # "CACHE": {
-    #     "default": {
-    #         "BACKEND": "unfazed.cache.backends.locmem.LocMemCache",
-    #         "LOCATION": PROJECT_NAME,
-    #     },
-    # },
+    "UNFAZED_CONTRIB_AUTH_SETTINGS": {
+        "USER_MODEL": "myapp.models.User",
+    },
+    "DATABASE": {
+        "CONNECTIONS": {
+            "default": {
+                "ENGINE": "tortoise.backends.mysql",
+                "CREDENTIALS": {
+                    "HOST": "mysql",
+                    "PORT": 3306,
+                    "USER": "root",
+                    "PASSWORD": "app",
+                    "DATABASE": "app",
+                },
+            }
+        },
+        "APPS": {
+            "models": {
+                "MODELS": [
+                    "aerich.models",
+                    "myapp.models",
+                    "unfazed.contrib.auth.models",
+                    "unfazed.contrib.admin.models",
+                ]
+            }
+        },
+    },
+    "CACHE": {
+        "default": {
+            "BACKEND": "unfazed.cache.backends.locmem.LocMemCache",
+            "LOCATION": PROJECT_NAME,
+        },
+    },
     "MIDDLEWARE": ["unfazed.middleware.internal.common.CommonMiddleware"],
     "LOGGING": {
         "formatters": {

--- a/examples/myprj/src/backend/myapp/models.py
+++ b/examples/myprj/src/backend/myapp/models.py
@@ -1,4 +1,10 @@
 from tortoise import Model, fields
+from unfazed.contrib.auth.models import AbstractUser
+
+
+class User(AbstractUser):
+    class Meta:
+        table = "myapp_user"
 
 
 class Student(Model):
@@ -28,8 +34,8 @@ class Course(Model):
 
 class StudentCourse(Model):
     id = fields.IntField(pk=True)
-    student = fields.ForeignKeyField("models.Student", related_name="courses")
-    course = fields.ForeignKeyField("models.Course", related_name="students")
+    student = fields.ForeignKeyField("models.Student", related_name="student_courses")
+    course = fields.ForeignKeyField("models.Course", related_name="course_students")
 
     class Meta:
         table = "student_course"

--- a/examples/myprj/src/backend/pyproject.toml
+++ b/examples/myprj/src/backend/pyproject.toml
@@ -5,6 +5,7 @@ description = "A myprj project."
 authors = []
 dependencies = [
     "ipython>=9.4.0",
+    "tortoise-orm==1.1.7",
     "unfazed",
 ]
 

--- a/examples/myprj/src/backend/uv.lock
+++ b/examples/myprj/src/backend/uv.lock
@@ -1,20 +1,20 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
 name = "aerich"
-version = "0.9.1"
+version = "0.9.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "anyio" },
     { name = "asyncclick" },
     { name = "dictdiffer" },
-    { name = "pydantic" },
     { name = "tortoise-orm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/98/75c6e3053a14a14ffe86e2435698b960abe0bf03c114e67f966d92ff19e7/aerich-0.9.1.tar.gz", hash = "sha256:629afbef5902635c41f410dd05def984c02e05e62d8a2020210a29a4aae19001", size = 35380, upload-time = "2025-06-16T03:23:57.741Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/59/94bd40ff5a9301bdd3e3c35704bb310e68542b5cbd4e09aba4c11ad7730e/aerich-0.9.3.tar.gz", hash = "sha256:b0caa932d795d84f0152f8dbf1019b4754ee9524acf92c8208e2e0de2480f482", size = 93468, upload-time = "2026-07-11T10:37:24.314Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/ad/ec20a5d4a9fa389a978b95314b4c800f20bda6e34c831ae252c5a7e2604c/aerich-0.9.1-py3-none-any.whl", hash = "sha256:6ff34a2104454d03f7473dc99e7ad51f405a909c261126a1b8a52d44ca7b4cbc", size = 39873, upload-time = "2025-06-16T03:23:56.562Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e4/28d09c59d529ae10843f09cb80c72dc4f1b2896b5b96ce0a431cc26c853a/aerich-0.9.3-py3-none-any.whl", hash = "sha256:153e1fbab55dd622638f0b5ca524945f1debcc4677e9402519053e4688b3a54c", size = 51072, upload-time = "2026-07-11T10:37:23.266Z" },
 ]
 
 [[package]]
@@ -475,6 +475,7 @@ version = "0.0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "ipython" },
+    { name = "tortoise-orm" },
     { name = "unfazed" },
 ]
 
@@ -494,7 +495,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "ipython", specifier = ">=9.4.0" },
-    { name = "unfazed", directory = "../../../../" },
+    { name = "tortoise-orm", specifier = "==1.1.7" },
+    { name = "unfazed", directory = "/unfazed" },
 ]
 
 [package.metadata.requires-dev]
@@ -770,11 +772,11 @@ wheels = [
 
 [[package]]
 name = "pypika-tortoise"
-version = "0.6.1"
+version = "0.6.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/db/03/c293fd42c3669e5a79d508c3ed1ca3ffa501600d93abd904a0f86d493ba0/pypika_tortoise-0.6.1.tar.gz", hash = "sha256:36ec2c88c255b9ed7ef49a6068cdeac10dafd4ddfeb828205d3afc092507fc3a", size = 39951, upload-time = "2025-06-04T14:11:53.915Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/06/89fe5fff93c5a01dbdeb9f3d843a7e997dc6e3a87222a260a164ff91fb81/pypika_tortoise-0.6.5.tar.gz", hash = "sha256:64d96c9b88450f6360ad22a7063933b6a90961a7317f04b2b63c98fd5d705506", size = 81468, upload-time = "2026-03-13T20:44:54.439Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/cd/fa8124fe37a2f1e8e362e128407b26e6a651dd6190a1e53c9fe5ab550842/pypika_tortoise-0.6.1-py3-none-any.whl", hash = "sha256:da15886f37b347e71f0869f9e4ee2f9259e6bb57455b45299c6c23d7927cbb6e", size = 46593, upload-time = "2025-06-04T14:11:52.977Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/b8/502910eb8b315f719d8f6a6509f13a38b6c4c05378f14ac151ff347bff0a/pypika_tortoise-0.6.5-py3-none-any.whl", hash = "sha256:9194ac6ce6ac9bdfc6e959c831c5788ef05ee1371e82ba281b0eb75f4a2bd4f1", size = 47936, upload-time = "2026-03-13T20:44:53.541Z" },
 ]
 
 [[package]]
@@ -838,15 +840,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
-]
-
-[[package]]
-name = "pytz"
-version = "2025.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
 ]
 
 [[package]]
@@ -968,17 +961,17 @@ wheels = [
 
 [[package]]
 name = "tortoise-orm"
-version = "0.25.1"
+version = "1.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiosqlite" },
+    { name = "anyio" },
     { name = "iso8601", marker = "python_full_version < '4'" },
-    { name = "pypika-tortoise", marker = "python_full_version < '4'" },
-    { name = "pytz" },
+    { name = "pypika-tortoise" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/9b/de966810021fa773fead258efd8deea2bb73bb12479e27f288bd8ceb8763/tortoise_orm-0.25.1.tar.gz", hash = "sha256:4d5bfd13d5750935ffe636a6b25597c5c8f51c47e5b72d7509d712eda1a239fe", size = 128341, upload-time = "2025-06-05T10:43:31.058Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/55/e75d3ae0dd2c96cf961bf068f465fb62ec481d802beb65f406620bfd40a0/tortoise_orm-1.1.7.tar.gz", hash = "sha256:a0f0f27f9c92547739f0a3f0862c257ab64d8baadbc0e548cbcfa2d70bcbe275", size = 387489, upload-time = "2026-03-21T20:03:29.087Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/55/2bda7f4445f4c07b734385b46d1647a388d05160cf5b8714a713e8709378/tortoise_orm-0.25.1-py3-none-any.whl", hash = "sha256:df0ef7e06eb0650a7e5074399a51ee6e532043308c612db2cac3882486a3fd9f", size = 167723, upload-time = "2025-06-05T10:43:29.309Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9b/e7e5b4f4e9433b9d9c389afc62ea0ed2597626842dc0f76dd7b54eb32cdd/tortoise_orm-1.1.7-py3-none-any.whl", hash = "sha256:b640b786905891cc120aa16d1a7af18cd54b111a812f9b1c1d1c7b294d62949d", size = 272437, upload-time = "2026-03-21T20:03:27.539Z" },
 ]
 
 [[package]]
@@ -1022,8 +1015,8 @@ wheels = [
 
 [[package]]
 name = "unfazed"
-version = "0.0.15b7"
-source = { directory = "../../../../" }
+version = "0.0.24"
+source = { directory = "/unfazed" }
 dependencies = [
     { name = "aerich" },
     { name = "anyio" },
@@ -1070,7 +1063,7 @@ dev = [
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-material", specifier = ">=9.5.49" },
     { name = "mkdocs-static-i18n", specifier = ">=1.2.3" },
-    { name = "mypy", specifier = ">=1.14.1" },
+    { name = "mypy", specifier = ">=1.19.0" },
     { name = "pymysql", specifier = ">=1.1.1" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-asyncio", specifier = ">=0.25.0" },

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -1,0 +1,296 @@
+import pytest
+from pydantic import ValidationError
+
+from unfazed.schema.orm import (
+    BaseCredential,
+    Connection,
+    Database,
+    MysqlCredential,
+    PgsqlCredential,
+    SqliteCredential,
+)
+
+
+class TestSqliteCredential:
+    def test_validate_all_pragmas(self) -> None:
+        cred = SqliteCredential.model_validate(
+            {
+                "FILE_PATH": "test.db",
+                "JOURNAL_MODE": "WAL",
+                "JOURNAL_SIZE_LIMIT": 16384,
+                "FOREIGN_KEYS": "ON",
+                "SYNCHRONOUS": "NORMAL",
+                "BUSY_TIMEOUT": 5000,
+                "CACHE_SIZE": -2000,
+                "TEMP_STORE": 2,
+                "WAL_AUTOCHECKPOINT": 1000,
+                "MMAP_SIZE": 268435456,
+                "LOCKING_MODE": "NORMAL",
+            }
+        )
+
+        assert cred.file_path == "test.db"
+        assert cred.journal_mode == "WAL"
+        assert cred.journal_size_limit == 16384
+        assert cred.foreign_keys == "ON"
+        assert cred.synchronous == "NORMAL"
+        assert cred.busy_timeout == 5000
+        assert cred.cache_size == -2000
+        assert cred.temp_store == 2
+        assert cred.wal_autocheckpoint == 1000
+        assert cred.mmap_size == 268435456
+        assert cred.locking_mode == "NORMAL"
+
+    def test_file_path_is_required(self) -> None:
+        with pytest.raises(ValidationError):
+            SqliteCredential.model_validate({"SYNCHRONOUS": "NORMAL"})
+
+    def test_dump_excludes_unset_pragmas(self) -> None:
+        cred = SqliteCredential.model_validate({"FILE_PATH": "test.db"})
+
+        assert cred.model_dump(exclude_none=True) == {"file_path": "test.db"}
+
+
+class TestBaseCredential:
+    def test_pool_size_defaults_to_none(self) -> None:
+        cred = BaseCredential.model_validate(
+            {"USER": "u", "PASSWORD": "p", "HOST": "h", "PORT": 5432, "DATABASE": "d"}
+        )
+
+        assert cred.minsize is None
+        assert cred.maxsize is None
+        assert cred.model_dump(exclude_none=True) == {
+            "user": "u",
+            "password": "p",
+            "host": "h",
+            "port": 5432,
+            "database": "d",
+        }
+
+
+class TestPgsqlCredential:
+    def test_validate_all_params(self) -> None:
+        cred = PgsqlCredential.model_validate(
+            {
+                "USER": "u",
+                "PASSWORD": "p",
+                "HOST": "h",
+                "PORT": 5432,
+                "DATABASE": "d",
+                "MIN_SIZE": 2,
+                "MAX_SIZE": 10,
+                "MAX_QUERIES": 50000,
+                "MAX_INACTIVE_CONNECTION_LIFETIME": 300.0,
+                "SSL": True,
+                "COMMAND_TIMEOUT": 2.5,
+                "TIMEOUT": 10,
+                "STATEMENT_CACHE_SIZE": 200,
+                "MAX_CACHED_STATEMENT_LIFETIME": 600,
+                "MAX_CACHEABLE_STATEMENT_SIZE": 2048,
+                "APPLICATION_NAME": "myapp",
+                "SERVER_SETTINGS": {"search_path": "public"},
+            }
+        )
+
+        assert cred.ssl is True
+        assert cred.command_timeout == 2.5
+        assert cred.timeout == 10.0
+        assert cred.statement_cache_size == 200
+        assert cred.max_cached_statement_lifetime == 600
+        assert cred.max_cacheable_statement_size == 2048
+        assert cred.application_name == "myapp"
+        assert cred.server_settings == {"search_path": "public"}
+
+    def test_ssl_accepts_bool(self) -> None:
+        cred = PgsqlCredential.model_validate(
+            {
+                "USER": "u",
+                "PASSWORD": "p",
+                "HOST": "h",
+                "PORT": 5432,
+                "DATABASE": "d",
+                "SSL": False,
+            }
+        )
+        assert cred.ssl is False
+
+    def test_timeout_accepts_float(self) -> None:
+        cred = PgsqlCredential.model_validate(
+            {
+                "USER": "u",
+                "PASSWORD": "p",
+                "HOST": "h",
+                "PORT": 5432,
+                "DATABASE": "d",
+                "COMMAND_TIMEOUT": 0.5,
+            }
+        )
+        assert cred.command_timeout == 0.5
+
+    def test_dump_excludes_unset_params(self) -> None:
+        cred = PgsqlCredential.model_validate(
+            {"USER": "u", "PASSWORD": "p", "HOST": "h", "PORT": 5432, "DATABASE": "d"}
+        )
+
+        assert cred.model_dump(exclude_none=True) == {
+            "user": "u",
+            "password": "p",
+            "host": "h",
+            "port": 5432,
+            "database": "d",
+        }
+
+
+class TestMysqlCredential:
+    def test_validate_all_params(self) -> None:
+        cred = MysqlCredential.model_validate(
+            {
+                "USER": "u",
+                "PASSWORD": "p",
+                "HOST": "h",
+                "PORT": 3306,
+                "DATABASE": "d",
+                "CONNECT_TIMEOUT": 10,
+                "CHARSET": "utf8mb4",
+                "SSL": {"ca": "/etc/ssl/certs/ca.pem"},
+                "ECHO": False,
+                "POOL_RECYCLE": 3600,
+                "READ_TIMEOUT": 30,
+                "USE_UNICODE": True,
+                "INIT_COMMAND": "SET time_zone='+8:00'",
+                "SQL_MODE": "STRICT_TRANS_TABLES",
+            }
+        )
+
+        assert cred.connect_timeout == 10
+        assert cred.charset == "utf8mb4"
+        assert cred.ssl == {"ca": "/etc/ssl/certs/ca.pem"}
+        assert cred.echo is False
+        assert cred.pool_recycle == 3600
+        assert cred.read_timeout == 30
+        assert cred.use_unicode is True
+        assert cred.init_command == "SET time_zone='+8:00'"
+        assert cred.sql_mode == "STRICT_TRANS_TABLES"
+
+    def test_ssl_accepts_dict(self) -> None:
+        cred = MysqlCredential.model_validate(
+            {
+                "USER": "u",
+                "PASSWORD": "p",
+                "HOST": "h",
+                "PORT": 3306,
+                "DATABASE": "d",
+                "SSL": {"ca": "/ca.pem", "cert": "/cert.pem"},
+            }
+        )
+        assert cred.ssl == {"ca": "/ca.pem", "cert": "/cert.pem"}
+
+    def test_dump_excludes_unset_params(self) -> None:
+        cred = MysqlCredential.model_validate(
+            {"USER": "u", "PASSWORD": "p", "HOST": "h", "PORT": 3306, "DATABASE": "d"}
+        )
+
+        assert cred.model_dump(exclude_none=True) == {
+            "user": "u",
+            "password": "p",
+            "host": "h",
+            "port": 3306,
+            "database": "d",
+        }
+
+
+class TestCredentialUnion:
+    def test_ssl_bool_discriminates_pgsql(self) -> None:
+        conn = Connection.model_validate(
+            {
+                "ENGINE": "tortoise.backends.asyncpg",
+                "CREDENTIALS": {
+                    "USER": "u",
+                    "PASSWORD": "p",
+                    "HOST": "h",
+                    "PORT": 5432,
+                    "DATABASE": "d",
+                    "SSL": True,
+                    "MAX_QUERIES": 50000,
+                },
+            }
+        )
+        assert isinstance(conn.credentials, PgsqlCredential)
+
+    def test_ssl_dict_discriminates_mysql(self) -> None:
+        conn = Connection.model_validate(
+            {
+                "ENGINE": "tortoise.backends.mysql",
+                "CREDENTIALS": {
+                    "USER": "u",
+                    "PASSWORD": "p",
+                    "HOST": "h",
+                    "PORT": 3306,
+                    "DATABASE": "d",
+                    "SSL": {"ca": "/ca.pem"},
+                    "CHARSET": "utf8mb4",
+                },
+            }
+        )
+        assert isinstance(conn.credentials, MysqlCredential)
+
+    def test_file_path_discriminates_sqlite(self) -> None:
+        conn = Connection.model_validate(
+            {
+                "ENGINE": "tortoise.backends.sqlite",
+                "CREDENTIALS": {"FILE_PATH": "test.db"},
+            }
+        )
+        assert isinstance(conn.credentials, SqliteCredential)
+
+
+class TestRemovedFields:
+    def test_autocommit_is_not_a_field(self) -> None:
+        assert "autocommit" not in MysqlCredential.model_fields
+
+    def test_schema_is_not_a_field(self) -> None:
+        assert "schema" not in PgsqlCredential.model_fields
+
+    def test_autocommit_input_is_ignored(self) -> None:
+        cred = MysqlCredential.model_validate(
+            {
+                "USER": "u",
+                "PASSWORD": "p",
+                "HOST": "h",
+                "PORT": 3306,
+                "DATABASE": "d",
+                "AUTOCOMMIT": True,
+            }
+        )
+        assert "autocommit" not in cred.model_dump(exclude_none=True)
+
+
+class TestDatabaseDump:
+    def test_model_dump_produces_tortoise_keys(self) -> None:
+        db = Database.model_validate(
+            {
+                "CONNECTIONS": {
+                    "default": {
+                        "ENGINE": "tortoise.backends.asyncpg",
+                        "CREDENTIALS": {
+                            "USER": "u",
+                            "PASSWORD": "p",
+                            "HOST": "h",
+                            "PORT": 5432,
+                            "DATABASE": "d",
+                            "SSL": True,
+                            "SERVER_SETTINGS": {"search_path": "public"},
+                        },
+                    }
+                }
+            }
+        )
+
+        dumped = db.model_dump(exclude_none=True)
+        credentials = dumped["connections"]["default"]["credentials"]
+
+        assert credentials["ssl"] is True
+        assert credentials["server_settings"] == {"search_path": "public"}
+        # aliases are resolved to Tortoise expected lowercase keys
+        assert "SSL" not in credentials
+        assert "SERVER_SETTINGS" not in credentials

--- a/tests/test_db/test_tortoise_driver.py
+++ b/tests/test_db/test_tortoise_driver.py
@@ -1,0 +1,21 @@
+from unittest.mock import patch
+
+from unfazed.db.tortoise.driver import Driver
+
+
+def test_tortoise_1x_enables_global_fallback() -> None:
+    with patch(
+        "unfazed.db.tortoise.driver.version",
+        return_value="1.0.0",
+    ):
+        assert Driver.get_tortoise_init_kwargs() == {
+            "_enable_global_fallback": True,
+        }
+
+
+def test_tortoise_pre_1x_does_not_enable_global_fallback() -> None:
+    with patch(
+        "unfazed.db.tortoise.driver.version",
+        return_value="0.25.4",
+    ):
+        assert Driver.get_tortoise_init_kwargs() == {}

--- a/tests/test_http/test_response.py
+++ b/tests/test_http/test_response.py
@@ -394,6 +394,19 @@ async def test_fileresponse_multiple_ranges() -> None:
     assert body.endswith(f"--{boundary}--\r\n".encode("latin-1"))
 
 
+def test_multipart_range_handler_content_length() -> None:
+    file_path = os.path.join(os.path.dirname(__file__), "zenofpython.txt")
+    handler = MultipartRangeFileHandler(
+        file_path,
+        [ByteRange(0, 5), ByteRange(10, 15)],
+        boundary="unfazed-boundary",
+        content_type="application/octet-stream",
+        file_size=os.path.getsize(file_path),
+    )
+
+    assert handler.content_length == len(b"".join(handler))
+
+
 def test_multipart_range_handler_errors_when_file_ends_early() -> None:
     file_path = os.path.join(os.path.dirname(__file__), "zenofpython.txt")
     file_size = os.stat(file_path).st_size

--- a/unfazed/db/tortoise/driver.py
+++ b/unfazed/db/tortoise/driver.py
@@ -1,5 +1,6 @@
 import logging
 import typing as t
+import warnings
 from importlib.metadata import version
 from pathlib import Path
 
@@ -70,7 +71,15 @@ class Driver(DataBaseDriver):
     @staticmethod
     def get_tortoise_init_kwargs() -> dict[str, bool]:
         # https://tortoise.github.io/setup.html#global-context-fallback
-        if Version(version("tortoise-orm")) >= Version("1.0.0"):
+        _current_version = version("tortoise-orm")
+        if Version(_current_version) >= Version("1.0.0"):
+            warnings.warn(
+                f"tortoise-orm {_current_version} (< 1.0.0) is deprecated: "
+                "support for versions below 1.0.0 will be removed in a future "
+                "release. Please upgrade to tortoise-orm>=1.0.0.",
+                FutureWarning,
+                stacklevel=2,
+            )
             return {"_enable_global_fallback": True}
 
         return {}

--- a/unfazed/db/tortoise/driver.py
+++ b/unfazed/db/tortoise/driver.py
@@ -1,7 +1,9 @@
 import logging
 import typing as t
+from importlib.metadata import version
 from pathlib import Path
 
+from packaging.version import Version
 from tortoise import Tortoise
 
 import unfazed
@@ -57,11 +59,21 @@ class Driver(DataBaseDriver):
         # init tortoise
         config = self.conf.model_dump(exclude_none=True)
         config.pop("driver")
-        await Tortoise.init(config=config)
+
+        _tortoise_init_kwargs: dict = self.get_tortoise_init_kwargs()
+        await Tortoise.init(config=config, **_tortoise_init_kwargs)
 
         # load aerich command
         for c in self.list_aerich_command():
             self.unfazed.command_center.load_command(c)
+
+    @staticmethod
+    def get_tortoise_init_kwargs() -> dict[str, bool]:
+        # https://tortoise.github.io/setup.html#global-context-fallback
+        if Version(version("tortoise-orm")) >= Version("1.0.0"):
+            return {"_enable_global_fallback": True}
+
+        return {}
 
     async def migrate(self) -> None:
         """Generate database schemas for all registered models.

--- a/unfazed/schema/orm.py
+++ b/unfazed/schema/orm.py
@@ -13,6 +13,13 @@ class SqliteCredential(BaseModel):
     journal_mode: str | None = Field(default=None, alias="JOURNAL_MODE")
     journal_size_limit: int | None = Field(default=None, alias="JOURNAL_SIZE_LIMIT")
     foreign_keys: str | None = Field(default=None, alias="FOREIGN_KEYS")
+    synchronous: str | None = Field(default=None, alias="SYNCHRONOUS")
+    busy_timeout: int | None = Field(default=None, alias="BUSY_TIMEOUT")
+    cache_size: int | None = Field(default=None, alias="CACHE_SIZE")
+    temp_store: int | None = Field(default=None, alias="TEMP_STORE")
+    wal_autocheckpoint: int | None = Field(default=None, alias="WAL_AUTOCHECKPOINT")
+    mmap_size: int | None = Field(default=None, alias="MMAP_SIZE")
+    locking_mode: str | None = Field(default=None, alias="LOCKING_MODE")
 
 
 class BaseCredential(BaseModel):
@@ -23,7 +30,6 @@ class BaseCredential(BaseModel):
     database: str = Field(..., alias="DATABASE")
     minsize: int | None = Field(default=None, alias="MIN_SIZE")
     maxsize: int | None = Field(default=None, alias="MAX_SIZE")
-    ssl: t.Optional[bool] = Field(default=None, alias="SSL")
 
 
 class PgsqlCredential(BaseCredential):
@@ -31,13 +37,32 @@ class PgsqlCredential(BaseCredential):
     max_inactive_connection_lifetime: float | None = Field(
         default=None, alias="MAX_INACTIVE_CONNECTION_LIFETIME"
     )
-    # schema: _[t.Any] = Field(None, alias="SCHEMA")
+    ssl: bool | None = Field(default=None, alias="SSL")
+    command_timeout: float | None = Field(default=None, alias="COMMAND_TIMEOUT")
+    timeout: float | None = Field(default=None, alias="TIMEOUT")
+    statement_cache_size: int | None = Field(default=None, alias="STATEMENT_CACHE_SIZE")
+    max_cached_statement_lifetime: int | None = Field(
+        default=None, alias="MAX_CACHED_STATEMENT_LIFETIME"
+    )
+    max_cacheable_statement_size: int | None = Field(
+        default=None, alias="MAX_CACHEABLE_STATEMENT_SIZE"
+    )
+    application_name: str | None = Field(default=None, alias="APPLICATION_NAME")
+    server_settings: dict[str, t.Any] | None = Field(
+        default=None, alias="SERVER_SETTINGS"
+    )
 
 
 class MysqlCredential(BaseCredential):
     connect_timeout: int | None = Field(default=None, alias="CONNECT_TIMEOUT")
-    echo: bool | None = Field(default=None, alias="ECHO")
     charset: str | None = Field(default=None, alias="CHARSET")
+    ssl: dict[str, t.Any] | None = Field(default=None, alias="SSL")
+    echo: bool | None = Field(default=None, alias="ECHO")
+    pool_recycle: int | None = Field(default=None, alias="POOL_RECYCLE")
+    read_timeout: int | None = Field(default=None, alias="READ_TIMEOUT")
+    use_unicode: bool | None = Field(default=None, alias="USE_UNICODE")
+    init_command: str | None = Field(default=None, alias="INIT_COMMAND")
+    sql_mode: str | None = Field(default=None, alias="SQL_MODE")
 
 
 class Connection(BaseModel):


### PR DESCRIPTION
因为 tortoise-orm 版本的原因，导致 tortoise-orm 1.x 之后的版本，在unfazed 里面无法正常初始化

这里使用 动态判断 tortoise-orm 版本，在初始化时传入不同的参数 解决